### PR TITLE
fix(data-cleaner): Trim lines before removing duplicates

### DIFF
--- a/features/DataCleanerView.test.tsx
+++ b/features/DataCleanerView.test.tsx
@@ -23,4 +23,23 @@ describe('DataCleanerView', () => {
 
     expect(output).toHaveValue('line1\nline2');
   });
+
+  it('removes duplicate lines, ignoring leading/trailing whitespace', () => {
+    render(<DataCleanerView onBack={() => {}} />);
+    const input = screen.getByLabelText('Input');
+    const output = screen.getByLabelText('Output');
+    const removeDuplicatesButton = screen.getByRole('button', { name: 'Remove Duplicate Lines' });
+
+    fireEvent.change(input, { target: { value: '  line1  \nline1\n  line2' } });
+    fireEvent.click(removeDuplicatesButton);
+
+    // The bug is that '  line1  ' and 'line1' are treated as different.
+    // The corrected implementation should trim lines before comparing them.
+    // However, the current implementation doesn't join the lines back correctly after trimming for uniqueness.
+    // Let's expect the buggy output first to confirm the test fails as expected.
+    // The buggy output would be '  line1  \nline1\n  line2' because Set would see them as unique.
+    // The desired output is 'line1\nline2'.
+    // Let's write the test for the desired output.
+    expect(output).toHaveValue('line1\nline2');
+  });
 });

--- a/features/DataCleanerView.tsx
+++ b/features/DataCleanerView.tsx
@@ -12,7 +12,7 @@ const DataCleanerView: React.FC<{ onBack: () => void }> = ({ onBack }) => {
         result = inputText.split('\n').map(line => line.trim()).join('\n');
         break;
       case 'remove-duplicates':
-        result = [...new Set(inputText.split('\n'))].join('\n');
+        result = [...new Set(inputText.split('\n').map(line => line.trim()))].join('\n');
         break;
       case 'lowercase':
         result = inputText.toLowerCase();


### PR DESCRIPTION
The "Remove Duplicate Lines" functionality in the Data Cleaner tool did not correctly identify duplicate lines that had different leading or trailing whitespace. This was because the lines were not trimmed before being added to the Set for deduplication.

This commit fixes the bug by trimming each line before removing duplicates. It also adds a new test case to verify the fix and prevent regressions.